### PR TITLE
Speeding up site generation in dev workflow

### DIFF
--- a/scripts/serve.ps1
+++ b/scripts/serve.ps1
@@ -1,17 +1,24 @@
 param (
-    [switch] $BuildUpFront
+    [switch] $ReusePreviousOutput,
+    [switch] $RenderUnpublished
 )
 
 $root = "$PSScriptRoot/.."
 
 $jekyllArgs = @()
-# if (!$BuildUpFront) {
-#     $jekyllArgs += "--skip-initial-build"
-# }
+if ($ReusePreviousOutput) {
+    $jekyllArgs += "--skip-initial-build"
+}
+if ($RenderUnpublished) {
+    $jekyllArgs += "--drafts"
+    $jekyllArgs += "--future"
+    $jekyllArgs += "--unpublished"
+}
 
 docker run --rm `
     --name="ivi-foundation-website" `
     --publish="4000:4000" `
     --volume="$root/site:/srv/jekyll:Z" `
+    --env JEKYLL_ENV=development `
     --rm --interactive --tty jekyll/jekyll `
-    jekyll serve --incremental --watch --force_polling --host 0.0.0.0 --trace @jekyllArgs
+    jekyll serve --incremental --watch --force_polling --profile --host 0.0.0.0 --trace @jekyllArgs

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "jekyll", "~> 4.3" # installed by `gem jekyll`
+gem "jekyll", "~> 4.3"
 
 gem "webrick"
 

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -83,7 +83,6 @@ GEM
     webrick (1.8.1)
 
 PLATFORMS
-  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -13,6 +13,7 @@ exclude:
  # from https://github.com/jekyll/jekyll/blob/master/lib/site_template/_config.yml:
    - .sass-cache/
    - .jekyll-cache/
+   - .jekyll-metadata
    - gemfiles/
    - Gemfile
    - Gemfile.lock
@@ -38,7 +39,7 @@ exclude:
 logo: "/assets/images/square-logo.png"
 
 
-# Put in  a favicon 
+# Put in a favicon
 favicon_ico: "/assets/images/favicon.ico"
 
 
@@ -167,6 +168,7 @@ kramdown:
     block:
       line_numbers: false
 
+# Compression docs: http://jch.penibelst.de/
 compress_html:
   clippings: all
   comments: all
@@ -174,5 +176,8 @@ compress_html:
   startings: []
   blanklines: false
   profile: false
-  # ignore:
-  #   envs: all
+
+  # Compressing the site makes HTML generation go from 30 seconds to 3 minutes. Let's only do that in production.
+  ignore:
+    envs:
+      - development


### PR DESCRIPTION
Compressing the site makes HTML generation go from 30 seconds to 3 minutes. It's not necessary to compress the HTML -- it's merely a way to save bandwidth during production. So let's skip doing it during development.

Related to #40