### PR TITLE
Oldsite Redirects

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -10,3 +10,5 @@ gem "jekyll-github-metadata"
 gem "just-the-docs"
 
 gem 'jekyll-sitemap'
+
+gem 'jekyll-redirect-from'

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,7 +1,8 @@
 title: IVI Foundation
 description: Incorporating Jekyll just-the-docs them into md derived from old site
 theme: just-the-docs
-baseurl: ""
+site.url: "https://192.168.10.89:4000"
+
 
 # This causes some sort of problem with the md->html generation (?) commenting out for now (JEM 2023-02-19)
 #permalink: pretty

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,7 +1,6 @@
 title: IVI Foundation
 description: Incorporating Jekyll just-the-docs them into md derived from old site
 theme: just-the-docs
-site.url: "https://192.168.10.89:4000"
 
 
 # This causes some sort of problem with the md->html generation (?) commenting out for now (JEM 2023-02-19)

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -163,6 +163,7 @@ plugins:
   - jekyll-seo-tag
   - jekyll-github-metadata
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 # jekyll-sitemap: the base hostname & protocol for the site
 url: "http://localhost:4000/"

--- a/site/index.md
+++ b/site/index.md
@@ -2,6 +2,8 @@
 layout: default
 nav_order: 0
 Title: "IVI Website"
+redirect_from: 
+    - index.aspx/
 ---
 
 # Welcome to the Interchangeable Virtual Instruments Foundation

--- a/site/shared_components/Default.md
+++ b/site/shared_components/Default.md
@@ -3,6 +3,12 @@ layout: default
 nav_order:  2
 title: Shared Components
 has_children: true
+redirect_from: 
+    - shared_components/default.aspx/
+    - Shared_components/default.aspx/
+    - shared_components/Default.aspx/
+    - Shared_Components/Default.aspx/
+    - Shared_components/Default.aspx/
 ---
 
 # Shared Components

--- a/site/specifications/default.md
+++ b/site/specifications/default.md
@@ -2,6 +2,11 @@
 layout: default
 title: Specifications
 nav_order:  3
+redirect_from: 
+    - specifications/default.aspx/
+    - specifications/Default.aspx/ 
+    - Specifications/default.aspx/ 
+    - Specifications/Default.aspx/ 
 ---
 
 This page has links to all of the current IVI specifications, including


### PR DESCRIPTION
This adds the gem for redirecting and applies it to the three files that obviously need it (the main page and the Specifications download page).

Note that jekyll respects URL case so we need to include common case variations in the redirects.

This works on a local system, but the redirected  URL is  always to the local server, even if served from another host.   So there is a problem with it, but it likely syntactically about right, subject to proper configuration.   This PR removes site.hostname setting from the _config.yml since it does not seem necessary for current behavior (and it will let whomever tries to fix this start with a clean slate).

I am not marking this as a draft PR since it works on local servers and probably needs something in the infrastructure changed to work properly (perhaps just an issue with 'jekyll serve -H 0.0.0.0:4000' that we won't see on a live site.

Subject to these caveats, I believe this satisfies issue #47.   We could determine additional pages need old site redirects, but these are the ones that come to mind for me.