### PR TITLE
Description is put in the HTML title, so make it meaningful

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,5 +1,5 @@
 title: IVI Foundation
-description: Incorporating Jekyll just-the-docs them into md derived from old site
+description: Standards for Instrument Communication & Control
 
 theme: just-the-docs
 


### PR DESCRIPTION
The current main page title on the live site looks like this:

![image](https://github.com/IviFoundation/ivifoundation.github.io/assets/75270571/2e87b8e8-3bbf-4dbc-837c-df1629346c1b)

This change makes it something more meaningful.  I'm open to any wordsmithing.

![image](https://github.com/IviFoundation/ivifoundation.github.io/assets/75270571/d5c79fc4-7611-4283-8a08-5a9101ceeb94)
