### PR TITLE
Redirect /contact_us.aspx to /About-the-Foundation/Contact-Us.html

### DIFF
--- a/site/About-the-Foundation/Contact-Us.md
+++ b/site/About-the-Foundation/Contact-Us.md
@@ -24,4 +24,4 @@ Greeley, CO 80634
 
 **IVI Members**
 
-To contact individual IVI Member companies, see: [Membership \> Current Members](membership/current_members.aspx)
+To contact individual IVI Member companies, see: [Membership \> Current Members](membership/current_members.html)

--- a/site/About-the-Foundation/Contact-Us.md
+++ b/site/About-the-Foundation/Contact-Us.md
@@ -2,6 +2,11 @@
 layout: default
 parent: About
 nav_order:  4
+redirect_from:
+    - Contact_Us.aspx/
+    - contact_Us.aspx/
+    - Contact_us.aspx/
+    - contact_us.aspx/
 title: Contact Us
 ---
 
@@ -19,4 +24,4 @@ Greeley, CO 80634
 
 **IVI Members**
 
-To contact individual IVI Member companies, see: [Membership \> Current Members](membership/current_members.html)
+To contact individual IVI Member companies, see: [Membership \> Current Members](membership/current_members.aspx)


### PR DESCRIPTION
Existing IVI Shared Components installers display the link http://ivifoundation.org/contact_us.aspx.  Forwarding this to the equivalent location in the new site will prevent broken links in shipping products.

Testing:

* Built & hosted in local Rancher instance
* http://localhost:4000/contact_us.aspx successfully redirects to http://0.0.0.0:4000/About-the-Foundation/Contact-Us.html
  * This doesn't load because of the weird way this handles localhost
  * However, other existing redirects (e.g., http://localhost:4000/shared_components/default.aspx) work the same way, so this seems sufficient