### PR TITLE
Fix links in code blocks, correct Pickering's site

### DIFF
--- a/site/About-the-Foundation/Current-Members.md
+++ b/site/About-the-Foundation/Current-Members.md
@@ -17,191 +17,202 @@ IVI has three classes of membership.  Sponsor, General, and Associate.
 
 **Keysight Technologies**
 
-    1400 Fountaingrove Pkwy
-    Santa Rosa, CA 95403
-    Web Page: [www.keysight.com](http://www.keysight.com/)
-    Business Contact: Steve Schink
-
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>1400 Fountaingrove Pkwy
+Santa Rosa, CA 95403
+Web Page: <a href="http://www.keysight.com">www.keysight.com</a>
+Business Contact: Steve Schink
+</code></pre></div></div>
 
 **NI (now part of Emerson)**
 
-    11500 N. Mopac Expwy., Building C
-    Austin, TX 78759-3504
-    Web Page: [www.ni.com](http://www.ni.com)
-    Business Contact: Nitin Thomas
-    Technical Contact: Alejandro Barreto
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>11500 N. Mopac Expwy., Building C
+Austin, TX 78759-3504
+Web Page: <a href="http://www.ni.com">www.ni.com</a>
+Business Contact: Nitin Thomas
+Technical Contact: Alejandro Barreto
+</code></pre></div></div>
 
 **Rohde & Schwarz**
 
-    Muehldorfstr. 15
-    81671 Munich, Germany
-    Web Page: [www.rohde-schwarz.com](http://www.rohde-schwarz.com)
-    Business/Technical Contact: [ Dr. Christian Hoelzl](mailto:%20christian.hoelzl@rohde-schwarz.com)
-    Phone: +49 89 4129 11555
-    Fax: +49 89 4129 61555
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>Muehldorfstr. 15
+81671 Munich, Germany
+Web Page: <a href="http://www.rohde-schwarz.com">www.rohde-schwarz.com</a>
+Business/Technical Contact: <a href="mailto:christian.hoelzl@rohde-schwarz.com">Dr. Christian Hoelzl</a>
+Phone: +49 89 4129 11555
+Fax: +49 89 4129 61555
+</code></pre></div></div>
 
 ## General Members
 
 **Astronics Test Systems**
 
-    4 Goodyear St.
-    Irvine, CA 92618
-    Web Page:
-    [www.astronicstestsystems.com](http://www.astronicstestsystems.com)
-    Business/Technical Contact:
-    Dan Masters
-    Phone: 1-949-460-6760
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>4 Goodyear St.
+Irvine, CA 92618
+Web Page: <a href="http://www.astronicstestsystems.com">www.astronicstestsystems.com</a>
+Business/Technical Contact: Dan Masters
+Phone: 1-949-460-6760
+</code></pre></div></div>
 
 **Bustec Ltd.**
 
-    Bustec House
-    Shannon Business Park
-    Shannon, Co. Clare IRELAND
-    Web Page: [www.bustec.com](http://www.bustec.com)
-    Business Contact: Dr. Fred Bloennigen
-    Phone: +353 61 707 100
-    Fax: +353 61 707 106
-    Technical Contact: Torsten Rissel
-    Phone: +353 61 707 102
-    Fax: +353 61 707 106
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>Bustec House
+Shannon Business Park
+Shannon, Co. Clare IRELAND
+Web Page: <a href="http://www.bustec.com">www.bustec.com</a>
+Business Contact: Dr. Fred Bloennigen
+Phone: +353 61 707 100
+Fax: +353 61 707 106
+Technical Contact: Torsten Rissel
+Phone: +353 61 707 102
+Fax: +353 61 707 106
+</code></pre></div></div>
 
 **MathWorks**
 
-    3 Apple Hill Drive
-    Natick, MA 01760
-    Web Page: [www.mathworks.com](http://www.mathworks.com)
-    Business/Technical Contact: Sean Sullivan
-    Phone: 508-647-7959
-    Fax: 508-647-7001
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>3 Apple Hill Drive
+Natick, MA 01760
+Web Page: <a href="http://www.mathworks.com">www.mathworks.com</a>
+Business/Technical Contact: Sean Sullivan
+Phone: 508-647-7959
+Fax: 508-647-7001
+</code></pre></div></div>
 
 **Pacific MindWorks, Inc.**
 
-    16870 West Bernardo Drive Suite 380
-    San Diego, CA 92127
-    Web Page: [www.pacificmindworks.com](http://www.pacificmindworks.com)
-    Contact: Kirk Fertitta
-    Phone: 858-587-8876 X237
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>16870 West Bernardo Drive Suite 380
+San Diego, CA 92127
+Web Page: <a href="http://www.pacificmindworks.com">www.pacificmindworks.com</a>
+Contact: Kirk Fertitta
+Phone: 858-587-8876 X237
+</code></pre></div></div>
 
 **Tektronix/Keithley Instruments**
 
-    14180 SW Karl Braun Drive
-    P.O. Box 500
-    MS 39-732
-    Beaverton, OR 97077
-    Web Page: [www.tek.com](http://www.tek.com)
-    Business Contact: Anshul Arora
-    Technical Contact: Santanu Pradhan
-    Phone: 91-80-3079-2453
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>14180 SW Karl Braun Drive
+P.O. Box 500
+MS 39-732
+Beaverton, OR 97077
+Web Page: <a href="http://www.tek.com">www.tek.com</a>
+Business Contact: Anshul Arora
+Technical Contact: Santanu Pradhan
+Phone: 91-80-3079-2453
+</code></pre></div></div>
 
 **Teradyne**
 
-    700 Riverpark Drive, MS-NR7001-2
-    North Reading, MA 01864
-    Web Page: [www.teradyne.com](http://www.teradyne.com)
-    Business/Technical Contact: Teresa Lopes
-    Phone: 978-370-1377
-    Fax: 978-370-1100
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>700 Riverpark Drive, MS-NR7001-2
+North Reading, MA 01864
+Web Page: <a href="http://www.teradyne.com">www.teradyne.com</a>
+Business/Technical Contact: Teresa Lopes
+Phone: 978-370-1377
+Fax: 978-370-1100
+</code></pre></div></div>
 
 ## Associate Members
 
 **Aim-TTi Ltd.**
 
-    Glebe Road
-    Huntingdon, Cambridgeshire PE29 7DR
-    United Kingdom
-    Web Page: [www.aimtti.com](http://www.aimtti.com)
-    Contact: Ian Harman
-    Phone: 0044 1480 412451
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>Glebe Road
+Huntingdon, Cambridgeshire PE29 7DR
+United Kingdom
+Web Page: <a href="http://www.aimtti.com">www.aimtti.com</a>
+Contact: Ian Harman
+Phone: 0044 1480 412451
+</code></pre></div></div>
 
 **AMETEK Programmable Power/VTI Instruments**
 
-    2031 Main St
-    Irvine, CA 92614
-    Web Page: <http://www.vtiinstruments.com/>
-    Business Contact: Chris Gibson
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>2031 Main St
+Irvine, CA 92614
+Web Page: <a href="http://www.vtiinstruments.com/">www.vtiinstruments.com</a>
+Business Contact: Chris Gibson
+</code></pre></div></div>
 
 **Chyng Hong Electronic Co., Ltd**
 
-    No.80, Lane 258, Sec. 3, Hansi W. Rd.,
-    Beitun District 40647, Taichung City Taiwan
-    Web Page: <http://www.idrc.com.tw>
-    Business Contact: Lily Chen
-    Phone: +886-4-243 76268 \#214
-    Fax: +886-4243 76266
-    Technical Contact: Simon Liu
-    Phone: +886-4-24376268 \#214
-    Fax: +886-4243 76266
-
-
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>No.80, Lane 258, Sec. 3, Hansi W. Rd.,
+Beitun District 40647, Taichung City Taiwan
+Web Page: <a href="http://www.idrc.com.tw">www.idrc.com.tw</a>
+Business Contact: Lily Chen
+Phone: +886-4-243 76268 \#214
+Fax: +886-4243 76266
+Technical Contact: Simon Liu
+Phone: +886-4-24376268 \#214
+Fax: +886-4243 76266
+</code></pre></div></div>
 
 **ELCOM, a.s.Technologicka 374/6**
 
-    70800 Ostrava-Pustkovec
-    Czech Republic
-    Web Page: <http://www.elcom.cz>
-    Business/Technical Contact: Jiri Kominek
-    Phone: +420558279911
-    Fax: +420555301279 </span>
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>70800 Ostrava-Pustkovec
+Czech Republic
+Web Page: <a href="http://www.elcom.cz">www.elcom.cz</a>
+Business/Technical Contact: Jiri Kominek
+Phone: +420558279911
+Fax: +420555301279
+</code></pre></div></div>
 
 **Kikusui Electronics, Corp.**
 
-    1-1-3 Higashiyamata
-    Tsuzuki-ku, Yokohama-city
-    Kanagawa-pref, 224-0023
-    JAPAN
-    Web Page:[www.kikusui.co.jp](http://www.kikusui.co.jp)
-    Business Contact: Hiroyuki Nakazawa
-    Technical Contact: Makoto Kondo
-    Phone: 81 45-593-7502
-    Fax: 81 45-593-0207
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>1-1-3 Higashiyamata
+Tsuzuki-ku, Yokohama-city
+Kanagawa-pref, 224-0023
+JAPAN
+Web Page: <a href="http://www.kikusui.co.jp">www.kikusui.co.jp</a>
+Business Contact: Hiroyuki Nakazawa
+Technical Contact: Makoto Kondo
+Phone: 81 45-593-7502
+Fax: 81 45-593-0207
+</code></pre></div></div>
 
 **NF Corporation**
 
-    6-3-20 Tsunashima Higashi Kohoku-ku
-    Yokohama 223-8508
-    JAPAN
-    Web Page: [www.nfcorp.co.jp](https://www.nfcorp.co.jp/)
-    Business Contact: Hirohito Iwaya
-    Phone: 81-45-545-8152
-    Technical Contact: Kazuyuki Murakami
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>6-3-20 Tsunashima Higashi Kohoku-ku
+Yokohama 223-8508
+JAPAN
+Web Page: <a href="https://www.nfcorp.co.jp/">www.nfcorp.co.jp</a>
+Business Contact: Hirohito Iwaya
+Phone: 81-45-545-8152
+Technical Contact: Kazuyuki Murakami
+</code></pre></div></div>
 
 **Pacific Power Source, Inc.**
 
-    17692 Fitch Irvine
-    CA 92614
-    Web Page: [pacificpower.com](https://pacificpower.com/)
-    Business/Technical Contact: Eric Lord
-    Phone: 949-251-1800
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>17692 Fitch Irvine
+CA 92614
+Web Page: [pacificpower.com](https://pacificpower.com/)
+Business/Technical Contact: Eric Lord
+Phone: 949-251-1800
+</code></pre></div></div>
 
 **Pickering Interfaces Ltd** 
 
-    Stephenson Road
-    Clacton-on-sea Essex CO15 4NL
-    England
-    Web Page:
-    [www.spectrum-instrumentation.com](http://www.spectrum-instrumentation.com/)
-    Business/Technical Contact: Alan P. Hum
-    Phone: +44 1255 687910
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>Stephenson Road
+Clacton-on-sea Essex CO15 4NL
+England
+Web Page: <a href="http://www.pickeringtest.com">www.pickeringtest.com</a>
+Business/Technical Contact: Alan P. Hum
+Phone: +44 1255 687910
+</code></pre></div></div>
 
 **Spectrum Instrumentation GmbH**
 
-    Ahrensfelder Weg 13-17
-    22927 Grosshansdorf
-    GERMANY
-    Web Page:
-    [www.spectrum-instrumentation.com](http://www.spectrum-instrumentation.com/)
-    Business Contact: Gisela Hassler
-    Phone: +49 4102 6956 0
-    Fax: +49 4102 6956 66
-    Technical Contact: Oliver Rovini
-    Phone: +49 4102 6956 0
-    Fax: +49 4102 6956 66
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>Ahrensfelder Weg 13-17
+22927 Grosshansdorf
+GERMANY
+Web Page: <a href="http://www.spectrum-instrumentation.com/">www.spectrum-instrumentation.com</a>
+Business Contact: Gisela Hassler
+Phone: +49 4102 6956 0
+Fax: +49 4102 6956 66
+Technical Contact: Oliver Rovini
+Phone: +49 4102 6956 0
+Fax: +49 4102 6956 66
+</code></pre></div></div>
 
 **Technical Software Engineering Plazotta GmbH**
 
-    Hopfenstr. 30, 85283 Wolnzach
-    Germany
-    Web Page: [http://www.tsep.com](http://www.tsep.com/)
-    Technical Contact:
-    David Courtney
-    Phone: +49 8442 96240 55
+<div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>Hopfenstr. 30, 85283 Wolnzach
+Germany
+Web Page: <a href="http://www.tsep.com/">www.tsep.com</a>
+Technical Contact: David Courtney
+Phone: +49 8442 96240 55
+</code></pre></div></div>


### PR DESCRIPTION
* Github Markdown does not support links in code blocks, so member company web site links were broken.  Copied the raw HTML formatting from the generated page and used that directly, adding HTML anchor tags for the links instead.
* Pickering's web site address was incorrect.  Updated it to what I think is the correct site.

### Before
![image](https://github.com/IviFoundation/ivifoundation.github.io/assets/75270571/d6bb996f-f9bd-4bec-a26b-d3f900da84e3)

### After
![image](https://github.com/IviFoundation/ivifoundation.github.io/assets/75270571/d1c26b44-55da-4b18-a826-b1229708fe59)
