### PR TITLE
LInks on this page not updated after site cleanup

### DIFF
--- a/site/About-IVI/default.md
+++ b/site/About-IVI/default.md
@@ -12,24 +12,25 @@ These pages will help you learn more about the IVI Foundation and IVI
 technology.
 
 
-- See [Driver Overview](overview.html) to get an overview of IVI Driver technology
+- See [Driver Overview](Driver-Overview.html) to get an overview of IVI Driver technology
   and benefits.
-- The [Architecture](architecture.html) page describes the overall IVI
+- The [Architecture](Driver-Architecture.html) page describes the overall IVI
   Driver software architecture, explaining the major software components and
   standard instrument classes.
-- [Instrument Classes](instrument_classes.html) specify standard APIs
+- [Instrument Classes](Instrument-Classes.html) specify standard APIs
   for common kinds of instruments to facilitate instrument interchange.
-- The [Measurement and Stimulus](MSS.html) page describes IVI's Measurement and Stimulus
+- The [Measurement and Stimulus](MeasurementAndStimulusInterchangeability.html) page 
+  describes IVI's Measurement and Stimulus
   Subsystem specification, which supports interchangeability in addition
   to that provided by common driver APIs.
-- [Conformance](conformance.html) explains IVI's process for assuring
+- [Conformance](Conformance.html) explains IVI's process for assuring
   that commercial drivers are conformant to the IVI specifications.
 - The [SCPI](scpi.html) page introduces the SCPI standard that 
   specifies the command strings sent to instruments to control them.
 - The [VXI_plug&play_](vxi_plugandplay.html) describes the VXI_plug&play_
   standards that broadly apply to the VISA IO library and C-language
   drivers.
-- Finally the [Member Resources](resources.html) page provides links to other
+- Finally the [Member Resources](MemberCompanyResources.html) page provides links to other
   web pages where you can to download  drivers, get  
   application information and review IVI-related software products.
 


### PR DESCRIPTION
Per title -- pages was the About IVI page.