### PR TITLE
Markdown syntax that caused yesterdays broken links

### DIFF
--- a/scripts/TrimUnusedBins.py
+++ b/scripts/TrimUnusedBins.py
@@ -140,7 +140,8 @@ def main():
 
 
 print("Program requires that MD link syntax is on a single line! Otherwise targets will be moved!!")
-print("   this is proper markdown syntax, but github seems to tolerate spanning two lines")
+print("   GitHub pages does tolerate spanning two lines, this scanner could be easily updated if needed")
+print("   by reading the file in one fell swoop (instead of one line at a time) and adjusting MDLINK_re")
 
 if not os.path.isdir("site"):
     print("Program must be run from root of repo... do not see site directory so quitting...")

--- a/site/getting-started/index.md
+++ b/site/getting-started/index.md
@@ -75,10 +75,8 @@ the following:
 
 - [Using IVI-Drivers with Python](../downloads/IVI%20GSG%202019/Getting%20Started%20with%20IVI%20and%20Python.pdf)
 - [Using IVI with Visual C++](../downloads/IVI%20short%20guides%202015/Using_IVI_with_Visual_C.pdf)
-- [Using IVI-COM with Visual C\# and Visual Basic .NET](
-    ../downloads/IVI%20short%20guides%202015/Using%20IVI%20with%20C%20and%20VB.pdf)
-- [Using IVI.NET with Visual C\# and Visual Basic .NET](
-    ../downloads/IVI%20short%20guides%202015/IVIshort_guides_2016/Using%20IVI.Net%20Drivers%20CS%20and%20VB%20Aug_8_2016.pdf)
+- [Using IVI-COM with Visual C\# and Visual Basic .NET](../downloads/IVI%20short%20guides%202015/Using%20IVI%20with%20C%20and%20VB.pdf)
+- [Using IVI.NET with Visual C\# and Visual Basic .NET](../downloads/IVI%20short%20guides%202015/IVIshort_guides_2016/Using%20IVI.Net%20Drivers%20CS%20and%20VB%20Aug_8_2016.pdf)
 - [Using IVI with LabVIEW](../downloads/IVI%20short%20guides%202015/Using%20IVI%20with%20LabVIEW.pdf)
 - [Using IVI with LabWindows/CVI](../downloads/IVI%20short%20guides%202015/Using%20IVI%20with%20LabWindows%20CVI.pdf)
 - [Using IVI with MATLAB](../downloads/IVI%20short%20guides%202015/Using%20IVI%20with%20MATLAB.pdf)


### PR DESCRIPTION
The broken links corrected yesterday was due to a unrecognized markdown syntax (links syntax spanned two lines) turns out the the website accepts the syntax but the python scanner used to remove unused files did not, so it had removed those files.

Verified that the syntax is not elsewhere by egrep'ing through all md files on the site for  '[', then egrepping through those lines for the absence of a close parenthesis.  This did not expose any other occurrences of the questionable syntax.

It appears that the syntax itself is not bad (specifically, a new line somewhere in the MD link syntax) since jekyll and friends seems to accept it (GFM presumably).

However, new website content can introduce this syntax so long as the python program is not used unchanged to scan for unused links again.

The second commit elaborates on the existing warning in the Python code regarding this limitation/flaw in the program (warning is printed when program is run).
