### PR TITLE
Move IVI SC 3.0.2 and IVI.NET SC 2.0.0 to older components pages

### DIFF
--- a/site/Shared-Components/OlderIviNetSharedComponents.md
+++ b/site/Shared-Components/OlderIviNetSharedComponents.md
@@ -10,6 +10,9 @@ nav_order: 3
 This page provides access to older versions of the IVI.NET Shared
 Components. To access the latest release, please see the main [Shared Components](Default.html) page.
 
+## IVI.NET Shared Components (32/64-bit) -- Older Versions
+- [IviNetSharedComponents\_200.exe](../downloads/Shared%20Components/IviNetSharedComponents_200.exe)
+
 ## IVI.NET Shared Components (32-bit) -- Older Versions
 
 - [IviNetSharedComponents32\_Fx20\_1.4.1.exe](../downloads/Shared%20Components/IviNetSharedComponents32_Fx20_1.4.1.exe)

--- a/site/Shared-Components/OlderIviSharedComponents.md
+++ b/site/Shared-Components/OlderIviSharedComponents.md
@@ -10,6 +10,9 @@ nav_order: 2
 This page provides access to older versions of the IVI Shared
 Components. To access the latest release, please see the main [Shared Components](Default.html) page.
 
+## IVI Shared Components (32/64-bit) -- Older Versions
+- [IviSharedComponents\_302.exe](../downloads/Shared%20Components/IviSharedComponents_302.exe)
+
 ## IVI Shared Components (32-bit) -- Older Versions
 
 - [IviSharedComponents\_261.exe](../downloads/Shared%20Components/x86/IviSharedComponents_261.exe)

--- a/site/Shared-Components/default.md
+++ b/site/Shared-Components/default.md
@@ -44,7 +44,6 @@ IVI-COM, IVI-C, or IVI.NET drivers. The IVI Shared Components require
 
 | ------------ | --------------- |
 | [IviSharedComponents\_303.exe](../downloads/Shared%20Components/IviSharedComponents_303.exe)  | This file is an executable installer that installs the IVI Shared Components on either a 32-bit or 64-bit system.This executable installer installs the same components as the MSI package. |
-| [IviSharedComponents\_302.exe](../downloads/Shared%20Components/IviSharedComponents_302.exe)  | This file is an executable installer that installs the IVI Shared Components on either a 32-bit or 64-bit system.This executable installer installs the same components as the MSI package. |
 | [Cleanup Utility (exe)](../downloads/Shared%20Components/x86/CleanupUtility.exe)  | Utility used to uninstall the IVI Shared Components version 2.2.1 or greater.                                                                                                               |
 | [IVI Shared Components Release Notes (docx)](../downloads/Shared%20Components/IVI%20Shared%20Components%20Release%20Notes%203.0.docx) | This document provides information on the current and previous versions of the IVI Shared Components, including known issues.    |
 | [Older IVI Shared Components Versions](OlderIviSharedComponents.html) | Download older versions of the IVI Shared Components.                                                                                                                                       |
@@ -61,7 +60,6 @@ greater.
 
 | ------------ | --------------- |
 | [IviNetSharedComponents\_201.exe](../downloads/Shared%20Components/IviNetSharedComponents_201.exe)  | This file is an executable installer that installs the IVI.NET Shared Components on either a 32-bit or 64-bit system. The IVI Shared Components 2.0.0 or greater (links above) **must be installed before installing the IVI.NET Shared Components**. |
-| [IviNetSharedComponents\_200.exe](../downloads/Shared%20Components/IviNetSharedComponents_200.exe)                               | This file is an executable installer that installs the IVI.NET Shared Components on either a 32-bit or 64-bit system. The IVI Shared Components 2.0.0 or greater (links above) **must be installed before installing the IVI.NET Shared Components**. |
 | [IVI.NET Shared Components Release Notes (docx)](../downloads/Shared%20Components/IVI.NET%20Shared%20Components%20Release%20Notes.docx) | This document provides information on the current and previous versions of the IVI.NET Shared Components, including known issues. |
 | [Older IVI.NET Shared Components Versions](OlderIviNetSharedComponents.html) | Download older versions of the IVI.NET Shared Components. |
 


### PR DESCRIPTION
Older components should be found on the "older components" pages instead of the main page