### PR TITLE
New (rather rough) script to serve the website using Kubernetes inste…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,126 @@ This is the IVI Foundation website, built on Jekyll and hosted on GitHub Pages.
 
 The DNS name "www.ivifoundation.org" points to this site.
 
-## Previewing locally on Windows
+## Previewing locally
 
-The easiest way to preview the site is to serve your local files in a [jekyll/jekyll](https://github.com/envygeeks/jekyll-docker) container.
+There are two ways to run the site locally. Both mount your working directory into a
+[jekyll/jekyll](https://github.com/envygeeks/jekyll-docker) container so edits are
+reflected without rebuilding the image.
 
-Prerequisites:
+| Approach | Script | URL | Requires |
+|---|---|---|---|
+| Docker (recommended) | `scripts/serve.ps1` | http://localhost:4000 | Docker |
+| Kubernetes | `scripts/kube-serve.ps1` | http://localhost:30400 | kubectl + Docker Desktop or Rancher Desktop |
 
-- Docker
-- PowerShell: `pwsh` (Linux) or `powershell.exe` (Windows, pre-installed)
+---
 
-Run this in PowerShell to build and serve the site:
+### Docker (recommended)
+
+**Prerequisites:** Docker, PowerShell (`pwsh` on Linux, `powershell.exe` on Windows)
 
 ```powershell
 .\scripts\serve.ps1
 ```
 
-It could take several minutes. Wait until you see:
+Wait until you see:
 
 ```
     Server address: http://0.0.0.0:4000
   Server running... press ctrl-c to stop.
 ```
 
-You can now open <http://localhost:4000/> in your browser to preview the site (**not** `0.0.0.0` as the output will show).
+Then open **http://localhost:4000** in your browser (`0.0.0.0` will not work — use `localhost`).
 
-The site will automatically rebuild when you make changes to the source files. However, because the site is so big (something we should optimize), it may take a minute or two for the changes to show up, or even for output to appear in the console saying that there was a change. Also, due to [incremental builds](https://jekyllrb.com/docs/configuration/incremental-regeneration/), some changes require the server to be restarted so it can rebuild the entire site.
+The server watches for file changes and rebuilds automatically. Because the site is large,
+rebuilds can take a minute or two. Some changes (e.g. `_config.yml`) require a full restart.
 
-You can stop the server by pressing `Ctrl+C`.
+Press `Ctrl+C` to stop.
 
-##  Previewing locally on Linux
+#### Optional flags
 
-You can perform development and updates to the site on Linux.  You can use a docker approach as outlined for Windows, or just install Jekyll and friends and serve it locally.
+| Flag | Effect |
+|---|---|
+| `-ReusePreviousOutput` | Skips the initial build, serving whatever was built last time |
+| `-RenderUnpublished` | Also renders draft posts, future-dated posts, and unpublished pages |
+
+```powershell
+.\scripts\serve.ps1 -RenderUnpublished
+```
+
+---
+
+### Kubernetes
+
+See [scripts/README.md](scripts/README.md) for full instructions and debugging steps.
+
+```powershell
+.\scripts\kube-serve.ps1
+```
+
+---
+
+## Debugging
+
+### Docker: container won't start or exits immediately
+
+Check whether a container from a previous run is still around:
+
+```powershell
+docker ps -a --filter name=ivi-foundation-website
+```
+
+If one exists, remove it and try again:
+
+```powershell
+docker rm -f ivi-foundation-website
+```
+
+### Docker: site not updating after a file change
+
+Incremental builds can occasionally miss changes. Restart the server to force a full rebuild:
+
+```powershell
+# Ctrl+C to stop, then:
+.\scripts\serve.ps1
+```
+
+If a full rebuild also looks wrong, delete the `_site/` output directory first:
+
+```powershell
+Remove-Item -Recurse -Force site/_site
+.\scripts\serve.ps1
+```
+
+### Docker: gem or bundle errors
+
+The `jekyll/jekyll` image bundles a fixed set of gems. If `Gemfile.lock` references a gem
+version not in the image you will see `Bundler::GemNotFound` errors. On Linux or WSL, run:
+
+```bash
+bundle install
+```
+
+to regenerate the lockfile, then restart the server.
+
+### Jekyll: page looks wrong or missing
+
+Jekyll's incremental build mode (used by `serve.ps1`) can skip some pages when
+dependencies change. Restart with a clean build to rule this out. If you need to preview
+unpublished or future-dated content, use the `-RenderUnpublished` flag.
+
+### Kubernetes issues
+
+See the [Debugging section in scripts/README.md](scripts/README.md#how-to-debug) for
+pod status checks, log streaming, and teardown instructions.
+
+---
+
+## Previewing locally on Linux
+
+The same Docker approach works on Linux. Install Docker, then run:
+
+```bash
+pwsh ./scripts/serve.ps1
+```
+
+Or install Jekyll directly and run `bundle exec jekyll serve` from the `site/` directory.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,13 +1,90 @@
-# Running the script to serve the site locally from Windows for development
+# Serving the site locally with Kubernetes
 
-kube-serve-ps1
+This script builds and serves the IVI Foundation website locally using Kubernetes
+(tested with Docker Desktop and Rancher Desktop). When running correctly the site is
+accessible at **http://localhost:30400**.
 
-This should be run from the root of the repo.  When working, you should be able to see the IVI Foundation website
-at http://localhost:30400.
+## Prerequisites
 
-The alternate script is setup for Rancher desktop/Kubernetes since many members do not run docker
-If changing gems, may be best to run 'bundle install' from Linux (another clone, or WSL).
+- **Kubernetes** running locally — Docker Desktop (with Kubernetes enabled) or Rancher Desktop
+- **kubectl** available on your PATH
+- **PowerShell** (5.1 or newer)
 
-Some familiarity with Kubernetes is important.  The script fires up some containers that you may need to delete (kubectl delete).
+## How to run
 
-Also, it creates a service to forward the internal kubernetes cluster port to local host so you can actually see it.
+Run from **any directory** — the script resolves all paths relative to its own location:
+
+```powershell
+.\scripts\kube-serve.ps1
+```
+
+The script will:
+1. Resolve the `site/` directory path and convert it to a format the cluster can mount
+2. Create a `jekyll/jekyll` pod that mounts your local `site/` directory
+3. Create a NodePort service that exposes the pod on `localhost:30400`
+4. Wait up to 5 minutes for the pod to become ready
+5. Print a message once the pod is running
+
+> **Note:** The pod runs `bundle install` before starting Jekyll, which can take several
+> minutes on a cold start. The site will not respond until that completes and you see
+> Jekyll output in the logs (see [Watching the logs](#watching-the-logs) below).
+
+## How to debug
+
+### Watching the logs
+
+Stream live output from the Jekyll container to see `bundle install` progress and confirm
+when the server is actually ready:
+
+```powershell
+kubectl logs -f pod/ivi-foundation-website
+```
+
+The site is ready once you see a line like:
+```
+Server running... press ctrl-c to stop.
+```
+
+### Checking pod status
+
+```powershell
+kubectl get pod ivi-foundation-website
+kubectl describe pod ivi-foundation-website
+```
+
+`describe` is the first place to look if the pod never becomes Ready — it shows image pull
+errors, volume mount failures, and other events.
+
+### Checking the service
+
+```powershell
+kubectl get service ivi-foundation-website
+```
+
+The `PORTS` column should show `4000:30400/TCP`. If the service is missing, re-run the script.
+
+### Tearing down
+
+The pod has `restartPolicy: Never` so it will not restart on its own. To stop and remove
+everything:
+
+```powershell
+kubectl delete pod ivi-foundation-website
+kubectl delete service ivi-foundation-website
+```
+
+Re-run the script to start fresh.
+
+### WSL / path issues
+
+The script automatically converts the Windows host path (e.g. `C:\Users\...`) to the
+`/mnt/c/...` format expected by clusters running inside WSL. If the volume fails to mount,
+check that the converted path printed in the pod description matches your actual checkout
+location.
+
+### Gem changes
+
+If you change `Gemfile` or `Gemfile.lock`, the container will re-run `bundle install` on
+the next start. For a faster iteration cycle when updating gems it can be easier to run
+`bundle install` from a Linux environment (WSL or another clone) to update the lockfile
+before restarting the pod.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+# Running the script to serve the site locally from Windows for development
+
+kube-serve-ps1
+
+This should be run from the root of the repo.  When working, you should be able to see the IVI Foundation website
+at http://localhost:30400.
+
+The alternate script is setup for Rancher desktop/Kubernetes since many members do not run docker
+If changing gems, may be best to run 'bundle install' from Linux (another clone, or WSL).
+
+Some familiarity with Kubernetes is important.  The script fires up some containers that you may need to delete (kubectl delete).
+
+Also, it creates a service to forward the internal kubernetes cluster port to local host so you can actually see it.

--- a/scripts/kube-serve.ps1
+++ b/scripts/kube-serve.ps1
@@ -17,6 +17,21 @@
 #     $jekyllArgs += "--unpublished"
 # }
 
+# Resolve the repo root as an absolute path (parent of the scripts/ directory).
+# $PSScriptRoot is always the directory containing this script, regardless of where
+# the user runs it from, so this works for any checkout location.
+$sitePath = (Resolve-Path "$PSScriptRoot\..\site").Path
+
+# If your Kubernetes cluster is running on WSL, you may need to adjust the path to the
+# site directory to be compatible with WSL. For example, if your site directory is located
+# at C:\folder1\IviWebsite\ivifoundation.github.io\site, you would use the following path
+# in the Kubernetes YAML: /mnt/c/folder1/IviWebsite/ivifoundation.github.io/site. 
+# You can try to do that automatically with a command like this:
+if ($sitePath -match '^([A-Z]):\\(.*)') {
+    $sitePath = '/mnt/' + $Matches[1].ToLower() + '/' + $Matches[2] -replace '\\', '/'
+}
+
+
 # Create the temporary Kubernetes YAML file for the pod
 $tmp_kube_yaml= New-TemporaryFile
 
@@ -66,18 +81,10 @@ spec:
   volumes:
     - name: site
       hostPath:
-        path: /mnt/c/Users/jmueller/git-ivi/website/ivifoundation.github.io/site
+        path: $sitePath
         type: Directory
 "@ | Set-Content $tmp_kube_yaml
 
-
-# warning - parameters to force rebuild hard coded in yaml for now 
-kubectl apply -f $tmp_kube_yaml
-kubectl port-forward pod/ivi-foundation-website 4000:4000
-
-
-# now create a service to forward the port 
-# Kubernetes port forwarding is a bit more complex than Docker's, so we need to create a temporary YAML file for the service as well. This service will allow us to access the Jekyll server running in the pod on port 4000 from our local machine.  Otherwise the Jekyll server will only be accessible from within the cluster, which is not what we want for development purposes.
 
 $tmp_portforward_yaml = New-TemporaryFile
 @"
@@ -95,7 +102,20 @@ spec:
       nodePort: 30400
 "@ | Set-Content $tmp_portforward_yaml
 
+kubectl apply -f $tmp_kube_yaml
 kubectl apply -f $tmp_portforward_yaml
 
+Remove-Item -Force "$tmp_kube_yaml"
+Remove-Item -Force "$tmp_portforward_yaml"
 
-Remove-Item  -Force "$tmp_kube_yaml"
+# Wait for the container to start (restartPolicy:Never pods become Ready as soon as the
+# process launches, which is before bundle install finishes — so this just confirms the
+# pod is alive, not that Jekyll is serving yet).
+Write-Host "Waiting for pod to start..."
+kubectl wait --for=condition=Ready pod/ivi-foundation-website --timeout=300s
+
+
+Write-Host "The site will be accessible at http://localhost:30400. It might take a few minutes!"
+
+
+

--- a/scripts/kube-serve.ps1
+++ b/scripts/kube-serve.ps1
@@ -1,0 +1,101 @@
+
+# NOTE THAT WHEN ALL IS WORKING WELL THE IVI FOUNDATION WEBSITE SHOULD BE ACCESSIBLE AT http://localhost:30400.  (JM)
+
+# Not currently integrated into this development tool (JM)
+# param (
+#     [switch] $ReusePreviousOutput,
+#     [switch] $RenderUnpublished
+# )
+
+# $jekyllArgs = @()
+# if ($ReusePreviousOutput) {
+#     $jekyllArgs += "--skip-initial-build"
+# }
+# if ($RenderUnpublished) {
+#     $jekyllArgs += "--drafts"
+#     $jekyllArgs += "--future"
+#     $jekyllArgs += "--unpublished"
+# }
+
+# Create the temporary Kubernetes YAML file for the pod
+$tmp_kube_yaml= New-TemporaryFile
+
+
+# Removed flags:
+# - --incremental
+#       This is known dangerous in a containerized environment, as it can cause the site to not rebuild when files change. For development, it's better to force a full rebuild on each change to ensure that all changes are reflected correctly. (JM)
+# - --watch 
+#       This is not needed when using --force_polling, as it will automatically watch for changes. Additionally, in a containerized environment, the file system events may not be properly detected, so relying on polling is more reliable. (JM)
+#
+
+@"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ivi-foundation-website
+  labels:
+    app: ivi-foundation-website
+spec:
+  restartPolicy: Never
+  containers:
+    - name: jekyll
+      image: jekyll/jekyll
+      env:
+        - name: JEKYLL_ENV
+          value: development
+        - name: JEKYLL_SASS_IMPLEMENTATION
+          value: sassc
+      args:
+        - sh
+        - -c
+        - |
+          bundle install &&
+          bundle exec jekyll serve \
+            --force_polling \
+            --profile \
+            --host 0.0.0.0 \
+            --trace \
+            --drafts \
+            --future \
+            --unpublished
+      ports:
+        - containerPort: 4000
+      volumeMounts:
+        - name: site
+          mountPath: /srv/jekyll
+  volumes:
+    - name: site
+      hostPath:
+        path: /mnt/c/Users/jmueller/git-ivi/website/ivifoundation.github.io/site
+        type: Directory
+"@ | Set-Content $tmp_kube_yaml
+
+
+# warning - parameters to force rebuild hard coded in yaml for now 
+kubectl apply -f $tmp_kube_yaml
+kubectl port-forward pod/ivi-foundation-website 4000:4000
+
+
+# now create a service to forward the port 
+# Kubernetes port forwarding is a bit more complex than Docker's, so we need to create a temporary YAML file for the service as well. This service will allow us to access the Jekyll server running in the pod on port 4000 from our local machine.  Otherwise the Jekyll server will only be accessible from within the cluster, which is not what we want for development purposes.
+
+$tmp_portforward_yaml = New-TemporaryFile
+@"
+apiVersion: v1
+kind: Service
+metadata:
+  name: ivi-foundation-website
+spec:
+  type: NodePort
+  selector:
+    app: ivi-foundation-website
+  ports:
+    - port: 4000
+      targetPort: 4000
+      nodePort: 30400
+"@ | Set-Content $tmp_portforward_yaml
+
+kubectl apply -f $tmp_portforward_yaml
+
+
+Remove-Item  -Force "$tmp_kube_yaml"

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -7,9 +7,11 @@ gem "webrick"
 # If you have any plugins, put them here! Or you may have weird errors:
 #   https://github.com/jekyll/jekyll/issues/6358#issuecomment-339859914
 group :jekyll_plugins do
-    gem "just-the-docs"
+    gem "just-the-docs", "~> 0.10.2"
+    gem "jekyll-sass-converter", "< 3.0"
     gem "jekyll-github-metadata"
     gem 'jekyll-sitemap'
     gem 'jekyll-redirect-from'
+    gem "sassc"
     #gem "jekyll-feed", "~> 0.6"
 end

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -14,9 +14,9 @@ GEM
       logger
     faraday-net_http (3.1.1)
       net-http
-    ffi (1.17.0)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    google-protobuf (3.25.5-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -43,15 +43,15 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    just-the-docs (0.8.2)
+    just-the-docs (0.10.2)
       jekyll (>= 3.8.5)
       jekyll-include-cache
       jekyll-seo-tag (>= 2.0)
@@ -74,16 +74,15 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
-    rake (13.2.1)
+    rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.2)
     rouge (4.3.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.5)
-      google-protobuf (~> 3.23)
-      rake (>= 13.0.0)
+    sassc (2.4.0)
+      ffi (~> 1.9)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -101,8 +100,10 @@ DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-github-metadata
   jekyll-redirect-from
+  jekyll-sass-converter (< 3.0)
   jekyll-sitemap
-  just-the-docs
+  just-the-docs (~> 0.10.2)
+  sassc
   webrick
 
 BUNDLED WITH

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -8,6 +8,9 @@ theme: just-the-docs
 # jekyll-sitemap: the base hostname & protocol for the site
 url: "https://ivifoundation.org"
 
+# as of 2026-04-09 HitHub pages uses sassc, so this better aligns with it, and works better for local development on Windows
+sass:
+  implementation: sassc
 
 # This causes some sort of problem with the md->html generation (?) commenting out for now (JEM 2023-02-19)
 #permalink: pretty


### PR DESCRIPTION
This is based on Alejandro's original work, but several changes.

Amongst other things, some Gem's had to be updated, but it seems these changes actually bring our website in-line with Github pages.

Probably should merge this into the CoreDoc branch for a couple of reasons:

1. This way we only have a single infrastructure update to the live website (really just new Gems and a new template)
2. While the CoreDoc branch is being evaluated we will benefit from having the Windows hosted server running.

As such, it probably makes sense to merge this into joe/CoreDoc instead of into main directly.
